### PR TITLE
Disable border color for search input

### DIFF
--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -101,10 +101,16 @@ class _SelectionListState extends State<SelectionList> {
                   ),
                   Container(
                     color: Colors.white,
-                    padding: EdgeInsets.all(20.0),
                     child: TextField(
                       controller: _controller,
-                      decoration: InputDecoration.collapsed(
+                      decoration: InputDecoration(
+                        border: InputBorder.none,
+                        focusedBorder: InputBorder.none,
+                        enabledBorder: InputBorder.none,
+                        errorBorder: InputBorder.none,
+                        disabledBorder: InputBorder.none,
+                        contentPadding:
+                        EdgeInsets.only(left: 15, bottom: 0, top: 0, right: 15),
                         hintText: "Search...",
                       ),
                       onChanged: _filterElements,


### PR DESCRIPTION
When the border colour of `inputDecorationTheme` is set on the `theme` property of `MaterialApp` 

**Bug**
<img width="509" alt="Screen Shot 2020-09-13 at 11 14 10 AM" src="https://user-images.githubusercontent.com/17992720/93014620-8199f580-f5c3-11ea-97ed-0deebeff3088.png">

**Fix**
<img width="490" alt="Screen Shot 2020-09-13 at 1 21 07 PM" src="https://user-images.githubusercontent.com/17992720/93017028-acda1000-f5d6-11ea-8d7f-7bca898d8e92.png">

