### PR TITLE
fixed default initialSelection

### DIFF
--- a/lib/country_list_pick.dart
+++ b/lib/country_list_pick.dart
@@ -55,8 +55,8 @@ class _CountryListPickState extends State<CountryListPick> {
       selectedItem = elements.firstWhere(
           (e) =>
               (e.code.toUpperCase() == widget.initialSelection.toUpperCase()) ||
-              (e.dialCode == widget.initialSelection.toString()),
-          orElse: () => elements[0]);
+              (e.dialCode == widget.initialSelection),
+          orElse: () => elements[0] as CountryCode);
     } else {
       selectedItem = elements[0];
     }


### PR DESCRIPTION
Fixes the following issue where the initialSelection is not found:

The following _TypeError was thrown building Country(state: _CountryState#1a41c):
type '() => dynamic' is not a subtype of type '(() => CountryCode)?' of 'orElse'