### PR TITLE
Breaking Change: Customize appBar, countryBuilder, pickerBuilder

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,13 +25,30 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: CountryListPick(
-            appBarBackgroundColor: Colors.amber,
-            isShowFlag: true,
-            isShowTitle: true,
-            isShowCode: true,
-            isDownIcon: true,
+            appBar: AppBar(
+              backgroundColor: Colors.blue,
+              title: Text('Choisir un pays'),
+            ),
+            pickerBuilder: (context, CountryCode countryCode) {
+              return Row(
+                children: [
+                  Image.asset(
+                    countryCode.flagUri,
+                    package: 'country_list_pick',
+                  ),
+                  Text(countryCode.code),
+                  Text(countryCode.dialCode),
+                ],
+              );
+            },
+            theme: CountryTheme(
+              isShowFlag: true,
+              isShowTitle: true,
+              isShowCode: true,
+              isDownIcon: true,
+              showEnglishName: true,
+            ),
             initialSelection: '+62',
-            showEnglishName: true,
             onChanged: (CountryCode code) {
               print(code.name);
               print(code.code);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,15 +49,6 @@ class _MyAppState extends State<MyApp> {
               isShowTitle: true,
               isShowCode: true,
               isDownIcon: true,
-              systemUiOverlayStyle: () =>
-                  SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-                statusBarColor: Colors.white,
-                statusBarIconBrightness: Brightness.dark,
-                systemNavigationBarColor: Colors.white,
-                systemNavigationBarIconBrightness: Brightness.dark,
-                statusBarBrightness:
-                    Platform.isAndroid ? Brightness.dark : Brightness.light,
-              )),
               showEnglishName: true,
             ),
             initialSelection: '+62',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:country_list_pick/country_list_pick.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() => runApp(MyApp());
 
@@ -46,6 +49,15 @@ class _MyAppState extends State<MyApp> {
               isShowTitle: true,
               isShowCode: true,
               isDownIcon: true,
+              systemUiOverlayStyle: () =>
+                  SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+                statusBarColor: Colors.white,
+                statusBarIconBrightness: Brightness.dark,
+                systemNavigationBarColor: Colors.white,
+                systemNavigationBarIconBrightness: Brightness.dark,
+                statusBarBrightness:
+                    Platform.isAndroid ? Brightness.dark : Brightness.light,
+              )),
               showEnglishName: true,
             ),
             initialSelection: '+62',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,44 +5,44 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.0.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.1.3"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.0.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.14.13"
   country_list_pick:
     dependency: "direct dev"
     description:
@@ -54,16 +54,16 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,23 +78,23 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.8"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.1.8"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -104,57 +104,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.17"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.0.8"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"

--- a/lib/country_list_pick.dart
+++ b/lib/country_list_pick.dart
@@ -1,34 +1,35 @@
+import 'package:country_list_pick/country_selection_theme.dart';
 import 'package:country_list_pick/selection_list.dart';
 import 'package:country_list_pick/support/code_countries_en.dart';
 import 'package:country_list_pick/support/code_country.dart';
 import 'package:country_list_pick/support/code_countrys.dart';
 import 'package:flutter/material.dart';
 
+import 'support/code_country.dart';
+
 export 'support/code_country.dart';
 
+export 'country_selection_theme.dart';
+
 class CountryListPick extends StatefulWidget {
-  CountryListPick({
-    this.onChanged,
-    this.isShowFlag,
-    this.isDownIcon,
-    this.isShowCode,
-    this.isShowTitle,
-    this.initialSelection,
-    this.showEnglishName,
-    this.appBarBackgroundColor,
-  });
-  final bool isShowTitle;
-  final bool isShowFlag;
-  final bool isShowCode;
-  final bool isDownIcon;
+  CountryListPick(
+      {this.onChanged,
+      this.initialSelection,
+      this.appBar,
+      this.pickerBuilder,
+      this.countryBuilder,
+      this.theme});
   final String initialSelection;
-  final bool showEnglishName;
   final ValueChanged<CountryCode> onChanged;
-  final Color appBarBackgroundColor;
+  final PreferredSizeWidget appBar;
+  final Widget Function(BuildContext context, CountryCode countryCode)
+      pickerBuilder;
+  final CountryTheme theme;
+  final Widget Function(BuildContext context, CountryCode countryCode) countryBuilder;
 
   @override
   _CountryListPickState createState() {
-    List<Map> jsonList = showEnglishName ? countriesEnglish : codes;
+    List<Map> jsonList = this.theme?.showEnglishName ?? true ? countriesEnglish : codes;
 
     List elements = jsonList
         .map((s) => CountryCode(
@@ -63,14 +64,21 @@ class _CountryListPickState extends State<CountryListPick> {
   }
 
   void _awaitFromSelectScreen(
-      BuildContext context, Color appBarBackgroundColor) async {
+      BuildContext context, PreferredSizeWidget appBar, CountryTheme theme) async {
     final result = await Navigator.push(
         context,
         MaterialPageRoute(
           builder: (context) => SelectionList(
             elements,
             selectedItem,
-            appBarBackgroundColor: widget.appBarBackgroundColor,
+            appBar: widget.appBar ??
+                AppBar(
+                  backgroundColor: Theme.of(context).appBarTheme.color,
+                  title: Text("Select Country"),
+                  //centerTitle: true,
+                ),
+                theme: theme,
+                countryBuilder: widget.countryBuilder,
           ),
         ));
 
@@ -85,43 +93,45 @@ class _CountryListPickState extends State<CountryListPick> {
     return FlatButton(
       padding: EdgeInsets.symmetric(horizontal: 0.0),
       onPressed: () {
-        _awaitFromSelectScreen(context, widget.appBarBackgroundColor);
+        _awaitFromSelectScreen(context, widget.appBar, widget.theme);
       },
-      child: Flex(
-        direction: Axis.horizontal,
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          if (widget.isShowFlag == true)
-            Flexible(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                child: Image.asset(
-                  selectedItem.flagUri,
-                  package: 'country_list_pick',
-                  width: 32.0,
-                ),
-              ),
+      child: widget.pickerBuilder != null
+          ? widget.pickerBuilder(context, selectedItem)
+          : Flex(
+              direction: Axis.horizontal,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                if (widget.theme?.isShowFlag ?? true == true)
+                  Flexible(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                      child: Image.asset(
+                        selectedItem.flagUri,
+                        package: 'country_list_pick',
+                        width: 32.0,
+                      ),
+                    ),
+                  ),
+                if (widget.theme?.isShowCode ?? true == true)
+                  Flexible(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                      child: Text(selectedItem.toString()),
+                    ),
+                  ),
+                if (widget.theme?.isShowTitle ?? true == true)
+                  Flexible(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                      child: Text(selectedItem.toCountryStringOnly()),
+                    ),
+                  ),
+                if (widget.theme?.isDownIcon ?? true == true)
+                  Flexible(
+                    child: Icon(Icons.keyboard_arrow_down),
+                  )
+              ],
             ),
-          if (widget.isShowCode == true)
-            Flexible(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                child: Text(selectedItem.toString()),
-              ),
-            ),
-          if (widget.isShowTitle == true)
-            Flexible(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                child: Text(selectedItem.toCountryStringOnly()),
-              ),
-            ),
-          if (widget.isDownIcon == true)
-            Flexible(
-              child: Icon(Icons.keyboard_arrow_down),
-            )
-        ],
-      ),
     );
   }
 }

--- a/lib/country_selection_theme.dart
+++ b/lib/country_selection_theme.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class CountryTheme {
+  final String searchText;
+  final String searchHintText;
+  final String lastPickText;
+  final Color alphabetSelectedBackgroundColor;
+  final Color alphabetTextColor;
+  final Color alphabetSelectedTextColor;
+  final bool isShowTitle;
+  final bool isShowFlag;
+  final bool isShowCode;
+  final bool isDownIcon;
+  final String initialSelection;
+  final bool showEnglishName;
+
+  CountryTheme({
+    this.searchText,
+    this.searchHintText,
+    this.lastPickText,
+    this.alphabetSelectedBackgroundColor,
+    this.alphabetTextColor,
+    this.alphabetSelectedTextColor,
+    this.isShowTitle,
+    this.isShowFlag,
+    this.isShowCode,
+    this.isDownIcon,
+    this.initialSelection,
+    this.showEnglishName,
+  });
+}

--- a/lib/country_selection_theme.dart
+++ b/lib/country_selection_theme.dart
@@ -13,10 +13,10 @@ class CountryTheme {
   final bool isDownIcon;
   final String initialSelection;
   final bool showEnglishName;
-  final void Function() systemUiOverlayStyle;
+  //final void Function() systemUiOverlayStyle;
 
   CountryTheme({
-    this.systemUiOverlayStyle,
+    //this.systemUiOverlayStyle,
     this.searchText,
     this.searchHintText,
     this.lastPickText,

--- a/lib/country_selection_theme.dart
+++ b/lib/country_selection_theme.dart
@@ -13,8 +13,10 @@ class CountryTheme {
   final bool isDownIcon;
   final String initialSelection;
   final bool showEnglishName;
+  final void Function() systemUiOverlayStyle;
 
   CountryTheme({
+    this.systemUiOverlayStyle,
     this.searchText,
     this.searchHintText,
     this.lastPickText,

--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:country_list_pick/country_selection_theme.dart';
 import 'package:country_list_pick/support/code_country.dart';
 import 'package:flutter/material.dart';
@@ -83,6 +85,7 @@ class _SelectionListState extends State<SelectionList> {
 
   @override
   Widget build(BuildContext context) {
+    widget.theme?.systemUiOverlayStyle();
     height = MediaQuery.of(context).size.height;
     return Scaffold(
       appBar: widget.appBar,

--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:country_list_pick/country_selection_theme.dart';
 import 'package:country_list_pick/support/code_country.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'country_list_pick.dart';
 
@@ -85,106 +86,116 @@ class _SelectionListState extends State<SelectionList> {
 
   @override
   Widget build(BuildContext context) {
-    widget.theme?.systemUiOverlayStyle();
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+      statusBarColor: Colors.white,
+      statusBarIconBrightness: Brightness.dark,
+      systemNavigationBarColor: Colors.white,
+      systemNavigationBarIconBrightness: Brightness.dark,
+      statusBarBrightness:
+          Platform.isAndroid ? Brightness.dark : Brightness.light,
+    ));
     height = MediaQuery.of(context).size.height;
-    return Scaffold(
-      appBar: widget.appBar,
-      body: Container(
-        color: Color(0xfff4f4f4),
-        child: LayoutBuilder(builder: (context, contrainsts) {
-          diff = height - contrainsts.biggest.height;
-          _heightscroller = (contrainsts.biggest.height) / _alphabet.length;
-          _sizeheightcontainer = (contrainsts.biggest.height);
-          return Stack(
-            children: <Widget>[
-              CustomScrollView(
-                controller: _controllerScroll,
-                physics: const AlwaysScrollableScrollPhysics(),
-                slivers: [
-                  SliverToBoxAdapter(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(15.0),
-                          child: Text(widget.theme?.searchText ?? 'SEARCH'),
-                        ),
-                        Container(
-                          color: Colors.white,
-                          child: TextField(
-                            controller: _controller,
-                            decoration: InputDecoration(
-                              border: InputBorder.none,
-                              focusedBorder: InputBorder.none,
-                              enabledBorder: InputBorder.none,
-                              errorBorder: InputBorder.none,
-                              disabledBorder: InputBorder.none,
-                              contentPadding: EdgeInsets.only(
-                                  left: 15, bottom: 0, top: 0, right: 15),
-                              hintText:
-                                  widget.theme?.searchHintText ?? "Search...",
-                            ),
-                            onChanged: _filterElements,
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(15.0),
-                          child:
-                              Text(widget.theme?.lastPickText ?? 'LAST PICK'),
-                        ),
-                        Container(
-                          color: Colors.white,
-                          child: Material(
-                            color: Colors.transparent,
-                            child: ListTile(
-                              leading: Image.asset(
-                                widget.initialSelection.flagUri,
-                                package: 'country_list_pick',
-                                width: 32.0,
-                              ),
-                              title: Text(widget.initialSelection.name),
-                              trailing: Padding(
-                                padding: const EdgeInsets.only(right: 20.0),
-                                child: Icon(Icons.check, color: Colors.green),
-                              ),
-                            ),
-                          ),
-                        ),
-                        SizedBox(height: 15),
-                      ],
-                    ),
-                  ),
-                  SliverList(
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      return widget.countryBuilder != null ? widget.countryBuilder(
-                              context, countries.elementAt(index)) :
-                          getListCountry(countries.elementAt(index));
-                    }, childCount: countries.length),
-                  )
-                ],
-              ),
-              if (isShow == true)
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: GestureDetector(
-                    onVerticalDragUpdate: _onVerticalDragUpdate,
-                    onVerticalDragStart: _onVerticalDragStart,
-                    child: Container(
-                      height: 20.0 * 30,
-                      color: Colors.transparent,
+    return SafeArea(
+      child: Scaffold(
+        appBar: widget.appBar,
+        body: Container(
+          color: Color(0xfff4f4f4),
+          child: LayoutBuilder(builder: (context, contrainsts) {
+            diff = height - contrainsts.biggest.height;
+            _heightscroller = (contrainsts.biggest.height) / _alphabet.length;
+            _sizeheightcontainer = (contrainsts.biggest.height);
+            return Stack(
+              children: <Widget>[
+                CustomScrollView(
+                  controller: _controllerScroll,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  slivers: [
+                    SliverToBoxAdapter(
                       child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: []..addAll(
-                            List.generate(_alphabet.length,
-                                (index) => _getAlphabetItem(index)),
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.all(15.0),
+                            child: Text(widget.theme?.searchText ?? 'SEARCH'),
                           ),
+                          Container(
+                            color: Colors.white,
+                            child: TextField(
+                              controller: _controller,
+                              decoration: InputDecoration(
+                                border: InputBorder.none,
+                                focusedBorder: InputBorder.none,
+                                enabledBorder: InputBorder.none,
+                                errorBorder: InputBorder.none,
+                                disabledBorder: InputBorder.none,
+                                contentPadding: EdgeInsets.only(
+                                    left: 15, bottom: 0, top: 0, right: 15),
+                                hintText:
+                                    widget.theme?.searchHintText ?? "Search...",
+                              ),
+                              onChanged: _filterElements,
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(15.0),
+                            child:
+                                Text(widget.theme?.lastPickText ?? 'LAST PICK'),
+                          ),
+                          Container(
+                            color: Colors.white,
+                            child: Material(
+                              color: Colors.transparent,
+                              child: ListTile(
+                                leading: Image.asset(
+                                  widget.initialSelection.flagUri,
+                                  package: 'country_list_pick',
+                                  width: 32.0,
+                                ),
+                                title: Text(widget.initialSelection.name),
+                                trailing: Padding(
+                                  padding: const EdgeInsets.only(right: 20.0),
+                                  child: Icon(Icons.check, color: Colors.green),
+                                ),
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: 15),
+                        ],
+                      ),
+                    ),
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        return widget.countryBuilder != null
+                            ? widget.countryBuilder(
+                                context, countries.elementAt(index))
+                            : getListCountry(countries.elementAt(index));
+                      }, childCount: countries.length),
+                    )
+                  ],
+                ),
+                if (isShow == true)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: GestureDetector(
+                      onVerticalDragUpdate: _onVerticalDragUpdate,
+                      onVerticalDragStart: _onVerticalDragStart,
+                      child: Container(
+                        height: 20.0 * 30,
+                        color: Colors.transparent,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: []..addAll(
+                              List.generate(_alphabet.length,
+                                  (index) => _getAlphabetItem(index)),
+                            ),
+                        ),
                       ),
                     ),
                   ),
-                ),
-            ],
-          );
-        }),
+              ],
+            );
+          }),
+        ),
       ),
     );
   }
@@ -249,7 +260,10 @@ class _SelectionListState extends State<SelectionList> {
                     fontWeight: FontWeight.bold,
                     color:
                         widget.theme?.alphabetSelectedTextColor ?? Colors.white)
-                : TextStyle(fontSize: 12, fontWeight: FontWeight.w400, color: widget.theme?.alphabetTextColor ?? Colors.black),
+                : TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w400,
+                    color: widget.theme?.alphabetTextColor ?? Colors.black),
           ),
         ),
       ),

--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -1,17 +1,19 @@
+import 'package:country_list_pick/country_selection_theme.dart';
 import 'package:country_list_pick/support/code_country.dart';
 import 'package:flutter/material.dart';
 
-class SelectionList extends StatefulWidget {
-  SelectionList(
-    this.elements,
-    this.initialSelection, {
-    Key key,
-    this.appBarBackgroundColor,
-  }) : super(key: key);
+import 'country_list_pick.dart';
 
-  final Color appBarBackgroundColor;
+class SelectionList extends StatefulWidget {
+  SelectionList(this.elements, this.initialSelection,
+      {Key key, this.appBar, this.theme, this.countryBuilder})
+      : super(key: key);
+
+  final PreferredSizeWidget appBar;
   final List elements;
   final CountryCode initialSelection;
+  final CountryTheme theme;
+  final Widget Function(BuildContext context, CountryCode) countryBuilder;
 
   @override
   _SelectionListState createState() => _SelectionListState();
@@ -41,7 +43,8 @@ class _SelectionListState extends State<SelectionList> {
       return a.name.toString().compareTo(b.name.toString());
     });
     _controllerScroll = ScrollController();
-    _controller.addListener(_scrollListener);
+    //_controller.addListener(_scrollListener);
+    _controllerScroll.addListener(_scrollListener);
     super.initState();
   }
 
@@ -82,11 +85,7 @@ class _SelectionListState extends State<SelectionList> {
   Widget build(BuildContext context) {
     height = MediaQuery.of(context).size.height;
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: widget.appBarBackgroundColor,
-        title: Text("Select Country"),
-        centerTitle: true,
-      ),
+      appBar: widget.appBar,
       body: Container(
         color: Color(0xfff4f4f4),
         child: LayoutBuilder(builder: (context, contrainsts) {
@@ -95,55 +94,71 @@ class _SelectionListState extends State<SelectionList> {
           _sizeheightcontainer = (contrainsts.biggest.height);
           return Stack(
             children: <Widget>[
-              ListView(
+              CustomScrollView(
                 controller: _controllerScroll,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(15.0),
-                    child: Text('SEARCH'),
-                  ),
-                  Container(
-                    color: Colors.white,
-                    child: TextField(
-                      controller: _controller,
-                      decoration: InputDecoration(
-                        border: InputBorder.none,
-                        focusedBorder: InputBorder.none,
-                        enabledBorder: InputBorder.none,
-                        errorBorder: InputBorder.none,
-                        disabledBorder: InputBorder.none,
-                        contentPadding: EdgeInsets.only(
-                            left: 15, bottom: 0, top: 0, right: 15),
-                        hintText: "Search...",
-                      ),
-                      onChanged: _filterElements,
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(15.0),
+                          child: Text(widget.theme?.searchText ?? 'SEARCH'),
+                        ),
+                        Container(
+                          color: Colors.white,
+                          child: TextField(
+                            controller: _controller,
+                            decoration: InputDecoration(
+                              border: InputBorder.none,
+                              focusedBorder: InputBorder.none,
+                              enabledBorder: InputBorder.none,
+                              errorBorder: InputBorder.none,
+                              disabledBorder: InputBorder.none,
+                              contentPadding: EdgeInsets.only(
+                                  left: 15, bottom: 0, top: 0, right: 15),
+                              hintText:
+                                  widget.theme?.searchHintText ?? "Search...",
+                            ),
+                            onChanged: _filterElements,
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.all(15.0),
+                          child:
+                              Text(widget.theme?.lastPickText ?? 'LAST PICK'),
+                        ),
+                        Container(
+                          color: Colors.white,
+                          child: Material(
+                            color: Colors.transparent,
+                            child: ListTile(
+                              leading: Image.asset(
+                                widget.initialSelection.flagUri,
+                                package: 'country_list_pick',
+                                width: 32.0,
+                              ),
+                              title: Text(widget.initialSelection.name),
+                              trailing: Padding(
+                                padding: const EdgeInsets.only(right: 20.0),
+                                child: Icon(Icons.check, color: Colors.green),
+                              ),
+                            ),
+                          ),
+                        ),
+                        SizedBox(height: 15),
+                      ],
                     ),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.all(15.0),
-                    child: Text('LAST PICK'),
-                  ),
-                  Container(
-                    color: Colors.white,
-                    child: ListTile(
-                      leading: Image.asset(
-                        widget.initialSelection.flagUri,
-                        package: 'country_list_pick',
-                        width: 32.0,
-                      ),
-                      title: Text(widget.initialSelection.name),
-                      trailing: Padding(
-                        padding: const EdgeInsets.only(right: 20.0),
-                        child: Icon(Icons.check, color: Colors.green),
-                      ),
-                    ),
-                  ),
-                  SizedBox(height: 15),
-                ]..addAll(
-                    countries.map(
-                      (e) => getListCountry(e),
-                    ),
-                  ),
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate((context, index) {
+                      return widget.countryBuilder != null ? widget.countryBuilder(
+                              context, countries.elementAt(index)) :
+                          getListCountry(countries.elementAt(index));
+                    }, childCount: countries.length),
+                  )
+                ],
               ),
               if (isShow == true)
                 Align(
@@ -175,16 +190,19 @@ class _SelectionListState extends State<SelectionList> {
     return Container(
       height: 50,
       color: Colors.white,
-      child: ListTile(
-        leading: Image.asset(
-          e.flagUri,
-          package: 'country_list_pick',
-          width: 30.0,
+      child: Material(
+        color: Colors.transparent,
+        child: ListTile(
+          leading: Image.asset(
+            e.flagUri,
+            package: 'country_list_pick',
+            width: 30.0,
+          ),
+          title: Text(e.name),
+          onTap: () {
+            _sendDataBack(context, e);
+          },
         ),
-        title: Text(e.name),
-        onTap: () {
-          _sendDataBack(context, e);
-        },
       ),
     );
   }
@@ -214,7 +232,9 @@ class _SelectionListState extends State<SelectionList> {
           height: 20,
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: index == posSelected ? Colors.blue : Colors.transparent,
+            color: index == posSelected
+                ? widget.theme?.alphabetSelectedBackgroundColor ?? Colors.blue
+                : Colors.transparent,
             shape: BoxShape.circle,
           ),
           child: Text(
@@ -224,8 +244,9 @@ class _SelectionListState extends State<SelectionList> {
                 ? TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
-                    color: Colors.white)
-                : TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
+                    color:
+                        widget.theme?.alphabetSelectedTextColor ?? Colors.white)
+                : TextStyle(fontSize: 12, fontWeight: FontWeight.w400, color: widget.theme?.alphabetTextColor ?? Colors.black),
           ),
         ),
       ),
@@ -274,6 +295,16 @@ class _SelectionListState extends State<SelectionList> {
   }
 
   _scrollListener() {
+    int scrollPosition =
+        (_controllerScroll.position.pixels / _itemsizeheight).round();
+    if (scrollPosition < countries.length) {
+      String countryName = countries.elementAt(scrollPosition).name;
+      setState(() {
+        posSelected =
+            countryName[0].toUpperCase().codeUnitAt(0) - 'A'.codeUnitAt(0);
+      });
+    }
+
     if ((_controllerScroll.offset) >=
         (_controllerScroll.position.maxScrollExtent)) {}
     if (_controllerScroll.offset <=

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,51 +5,51 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.0.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.1.3"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.0.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.14.13"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -64,23 +64,23 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.8"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.1.8"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -90,57 +90,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.17"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.0.8"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"


### PR DESCRIPTION
Hi, I noticed that a lot of elements were hard coded. This pull request gives the following changes
1. Create its own appBar instead of relying on the default blue appBar currently implemented.
2. Create its own country item builder, the default is still implemented
3. Activate splash effects when selecting a country
4. Outsource the hint search Text and its text to better take into account internationalization
5. To avoid mixing the core functinality with the theme customization, a new class CountryTheme is created and contains everything concerning theme customization (`isShowTitle,  isShowFlag, isShowCode`) etc..  This keeps country_list_pick as simple as possible
6. Solve the issue in #5

Thanks for the great plugin