### PR TITLE
Make using the UI overlay optional and allow using SafeArea

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ To use this plugin, add `country_list_pick` as a [dependency in your pubspec.yam
         ),
         // Set default value
         initialSelection: '+62',
-          onChanged: (CountryCode code) {
-            print(code.name);
-            print(code.code);
-            print(code.dialCode);
-            print(code.flagUri);
-          },
+        onChanged: (CountryCode code) {
+          print(code.name);
+          print(code.code);
+          print(code.dialCode);
+          print(code.flagUri);
+        },
+        // Whether to allow the widget to set a custom UI overlay
+        useUiOverlay: true,
+        // Whether the country list should be wrapped in a SafeArea
+        useSafeArea: false
         ),
 ```
 

--- a/lib/country_list_pick.dart
+++ b/lib/country_list_pick.dart
@@ -18,7 +18,9 @@ class CountryListPick extends StatefulWidget {
       this.appBar,
       this.pickerBuilder,
       this.countryBuilder,
-      this.theme});
+      this.theme,
+      this.useUiOverlay = true,
+      this.useSafeArea = false});
   final String initialSelection;
   final ValueChanged<CountryCode> onChanged;
   final PreferredSizeWidget appBar;
@@ -27,6 +29,8 @@ class CountryListPick extends StatefulWidget {
   final CountryTheme theme;
   final Widget Function(BuildContext context, CountryCode countryCode)
       countryBuilder;
+  final bool useUiOverlay;
+  final bool useSafeArea;
 
   @override
   _CountryListPickState createState() {
@@ -80,6 +84,8 @@ class _CountryListPickState extends State<CountryListPick> {
                 ),
             theme: theme,
             countryBuilder: widget.countryBuilder,
+            useUiOverlay: widget.useUiOverlay,
+            useSafeArea: widget.useSafeArea,
           ),
         ));
 

--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -9,7 +9,8 @@ import 'country_list_pick.dart';
 
 class SelectionList extends StatefulWidget {
   SelectionList(this.elements, this.initialSelection,
-      {Key key, this.appBar, this.theme, this.countryBuilder})
+      {Key key, this.appBar, this.theme, this.countryBuilder,
+        this.useUiOverlay = true, this.useSafeArea = false})
       : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -17,6 +18,8 @@ class SelectionList extends StatefulWidget {
   final CountryCode initialSelection;
   final CountryTheme theme;
   final Widget Function(BuildContext context, CountryCode) countryBuilder;
+  final bool useUiOverlay;
+  final bool useSafeArea;
 
   @override
   _SelectionListState createState() => _SelectionListState();
@@ -86,16 +89,17 @@ class _SelectionListState extends State<SelectionList> {
 
   @override
   Widget build(BuildContext context) {
-    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-      statusBarColor: Colors.white,
-      statusBarIconBrightness: Brightness.dark,
-      systemNavigationBarColor: Colors.white,
-      systemNavigationBarIconBrightness: Brightness.dark,
-      statusBarBrightness:
-          Platform.isAndroid ? Brightness.dark : Brightness.light,
-    ));
+    if (widget.useUiOverlay)
+      SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+        statusBarColor: Colors.white,
+        statusBarIconBrightness: Brightness.dark,
+        systemNavigationBarColor: Colors.white,
+        systemNavigationBarIconBrightness: Brightness.dark,
+        statusBarBrightness:
+            Platform.isAndroid ? Brightness.dark : Brightness.light,
+      ));
     height = MediaQuery.of(context).size.height;
-    return Scaffold(
+    Widget scaffold = Scaffold(
       appBar: widget.appBar,
       body: Container(
         color: Color(0xfff4f4f4),
@@ -196,6 +200,7 @@ class _SelectionListState extends State<SelectionList> {
         }),
       ),
     );
+    return widget.useSafeArea ? SafeArea(child: scaffold) : scaffold;
   }
 
   Widget getListCountry(CountryCode e) {


### PR DESCRIPTION
When `country_list_pick` is used inside an app that uses `SafeArea`, using the widget's country selection list messes with the notification area of the device. This commit allows clients to choose whether `SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle()` should be applied and allows them to have the country selection list wrapped inside a `SafeArea` widget.