### PR TITLE
Remove the padding around the custom built picker

### DIFF
--- a/lib/country_list_pick.dart
+++ b/lib/country_list_pick.dart
@@ -97,8 +97,8 @@ class _CountryListPickState extends State<CountryListPick> {
 
   @override
   Widget build(BuildContext context) {
-    return TextButton(
-      onPressed: () {
+    return GestureDetector(
+      onTap: () {
         _awaitFromSelectScreen(context, widget.appBar, widget.theme);
       },
       child: widget.pickerBuilder != null

--- a/lib/selection_list.dart
+++ b/lib/selection_list.dart
@@ -6,6 +6,8 @@ import 'package:flutter/services.dart';
 
 import 'country_list_pick.dart';
 
+const Color kBackgroundColor = Color(0xFFFBFBFB);
+
 class SelectionList extends StatefulWidget {
   SelectionList(this.elements, this.initialSelection,
       {Key? key,
@@ -97,7 +99,7 @@ class _SelectionListState extends State<SelectionList> {
                           child: Text(widget.theme?.searchText ?? 'SEARCH'),
                         ),
                         Container(
-                          color: Colors.white,
+                          color: kBackgroundColor,
                           child: TextField(
                             controller: _controller,
                             decoration: InputDecoration(
@@ -120,7 +122,7 @@ class _SelectionListState extends State<SelectionList> {
                               Text(widget.theme?.lastPickText ?? 'LAST PICK'),
                         ),
                         Container(
-                          color: Colors.white,
+                          color: kBackgroundColor,
                           child: Material(
                             color: Colors.transparent,
                             child: ListTile(
@@ -181,7 +183,7 @@ class _SelectionListState extends State<SelectionList> {
   Widget getListCountry(CountryCode e) {
     return Container(
       height: 50,
-      color: Colors.white,
+      color: kBackgroundColor,
       child: Material(
         color: Colors.transparent,
         child: ListTile(


### PR DESCRIPTION
By replacing the TextButton with GestureDetector, the padding around the custom built picker would be removed because the TextButton has a default padding while GestureDetector not.