### PR TITLE
Add country name in other languages (because people in Belgium and Switzerland speak multiple languages)

### DIFF
--- a/lib/support/code_countrys.dart
+++ b/lib/support/code_countrys.dart
@@ -105,6 +105,11 @@ List<Map<String, String>> codes = [
     "dial_code": "+375",
   },
   {
+    "name": "Belgique",
+    "code": "BE",
+    "dial_code": "+32",
+  },
+  {
     "name": "België",
     "code": "BE",
     "dial_code": "+32",

--- a/lib/support/code_countrys.dart
+++ b/lib/support/code_countrys.dart
@@ -105,12 +105,7 @@ List<Map<String, String>> codes = [
     "dial_code": "+375",
   },
   {
-    "name": "Belgique",
-    "code": "BE",
-    "dial_code": "+32",
-  },
-  {
-    "name": "België",
+    "name": "Belgique - België",
     "code": "BE",
     "dial_code": "+32",
   },
@@ -1080,7 +1075,7 @@ List<Map<String, String>> codes = [
     "dial_code": "+46",
   },
   {
-    "name": "Schweiz",
+    "name": "Schweiz - Suisse - Svizzera",
     "code": "CH",
     "dial_code": "+41",
   },


### PR DESCRIPTION
- People in Belgium speak either French or Dutch.
- People in Switzerland speak either German, French or Italian